### PR TITLE
fixed duplicate priority number in recommended WAF rule order table

### DIFF
--- a/docs/en/guides/waf/recommended-waf-rule-order/docs/index.md
+++ b/docs/en/guides/waf/recommended-waf-rule-order/docs/index.md
@@ -59,7 +59,7 @@ The following table provides a more detailed recommendation of rule order.
 |  9 | AWS Managed Use-Case Rules (SQL Database, etc.) | Block | Application-specific threat coverage |
 | 10 | False Positive Exception and APpplication Specific Rules | Block |  False Positive handling or application specific protection |
 | 11 | Partner Manged Rules | Block | Varried types of protection.  Placing after free usage rules to reduce cost. |
-| 11 | Bot Control | Block/Challenge | Detect and manage bot traffic (with scope-down) |
+| 12 | Bot Control | Block/Challenge | Detect and manage bot traffic (with scope-down) |
 | 13 | Fraud Control (ATP, ACFP) | Block | Protect login and account creation pages (with scope-down) |
 
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Fixed a duplicate priority 11 in the rule order table (recommended-waf-rule-order) by renumbering the "Bot Control" row from 11 to 12.
https://aws.github.io/aws-security-services-best-practices/guides/waf/recommended-waf-rule-order/docs/

<img width="686" height="620" alt="image" src="https://github.com/user-attachments/assets/c41d8ab8-0c02-41fc-b4ef-04e88daeedd4" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.